### PR TITLE
fix: ページ幅を狭くしたときにコンテンツがはみ出るバグを修正

### DIFF
--- a/chrome-ext/src/content.js
+++ b/chrome-ext/src/content.js
@@ -23,3 +23,6 @@ for (i=0; i<tr.length; i++) {
     $perf.text(perf);
     $(td[5]).after($perf);
 }
+
+// ページ幅を狭くしたときにコンテンツがはみ出さないようにする
+$('#pageContent > div.datatable > div:nth-child(6)').css('overflow', 'scroll');

--- a/userscript/content.js
+++ b/userscript/content.js
@@ -101,4 +101,7 @@ $(function() {
             8: { sorter: false },
         }
     });
+
+    // ページ幅を狭くしたときにコンテンツがはみ出さないようにする
+    $('#pageContent > div.datatable > div:nth-child(6)').css('overflow', 'scroll');
 });


### PR DESCRIPTION
ページ幅を狭くしたときに追加したPerformances列の幅の分，テーブルからコンテンツがはみ出ていたため，スクロールできるように修正しました．

**Before:**

![before](https://user-images.githubusercontent.com/51394682/121784572-9f969400-cbef-11eb-9263-4253ed163a22.png)

**After:** 

https://user-images.githubusercontent.com/51394682/121784682-45e29980-cbf0-11eb-9964-ad56d9ea73d1.mov